### PR TITLE
Avoid direct command execution in recipe

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -4,14 +4,7 @@ driver_config:
   require_chef_omnibus: true
 
 platforms:
-# - name: ubuntu-12.04
-# driver_config:
-# box: opscode-ubuntu-12.04
-# box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/opscode_ubuntu-12.04_provisionerless.box
-  - name: ubuntu-13.04
-    driver_config:
-      box: opscode-ubuntu-13.04
-      box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/opscode_ubuntu-13.04_provisionerless.box
+  - name: ubuntu-14.04
 
 suites:
   - name: default
@@ -19,5 +12,8 @@ suites:
       - recipe[xdebug::default]
     attributes:
       xdebug:
+        stand_along: true
+        execute_php5enmod: true
+        config_file: '/etc/php5/mods-available/xdebug.ini'
         web_server:
           service_name: ''

--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,7 @@
 source 'https://supermarket.getchef.com'
 
 metadata
+
+cookbook 'apt'
+cookbook 'build-essential'
+cookbook 'php'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -11,3 +11,4 @@ default['xdebug']['config_file'] = nil
 default['xdebug']['execute_php5enmod'] = false
 default['xdebug']['web_server']['service_name'] = 'apache2'
 default['xdebug']['directives'] = {}
+default['xdebug']['stand_along'] = false

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,12 +4,13 @@ maintainer_email 'dev@escapestudios.com'
 license 'MIT'
 description 'Installs/Configures xdebug'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.0.0'
+version '1.0.1'
 
 %w( debian ubuntu redhat centos fedora scientific amazon windows smartos ).each do |os|
   supports os
 end
 
+depends 'apt'
 depends 'build-essential'
 depends 'php'
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -5,13 +5,15 @@
 # Copyright 2014, Escape Studios
 #
 
+include_recipe 'apt'
 include_recipe 'build-essential'
+include_recipe 'php' if node['xdebug']['stand_along']
 
 # install/upgrade xdebug
 package = 'xdebug'
 
 # upgrade when package is installed and latest version is required
-if !(`pear list | grep #{package}`.empty?) && node['xdebug']['version'] == 'latest'
+if Mixlib::ShellOut.new("pecl list | grep -i #{package}").run_command.stdout.downcase.include?('xdebug') && node['xdebug']['version'] == 'latest'
   action = :upgrade
 else
   action = :install
@@ -22,6 +24,8 @@ php_pear package do
   action action
   options node['xdebug']['pear_options'] unless node['xdebug']['pear_options'].empty?
 end
+
+#service 'apache2' if defined?(ChefSpec) #declare service to prevent unit testing component
 
 template node['xdebug']['config_file'] do
   source 'xdebug.ini.erb'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,11 @@
 require 'chefspec'
 require 'chefspec/berkshelf'
 
-at_exit { ChefSpec::Coverage.report! }
+ChefSpec::Coverage.start! do
+  add_filter(%r{build-essential})
+ end
+
+RSpec.configure do |config|
+  config.platform = 'ubuntu'
+  config.version = '14.04'
+end

--- a/spec/unit/default_spec.rb
+++ b/spec/unit/default_spec.rb
@@ -1,5 +1,72 @@
 require 'spec_helper'
 
 describe 'xdebug::default' do
-  let(:chef_run) { ChefSpec::Runner.new.converge(described_recipe) }
+
+  let(:shellout) { double('shellout') }
+  let(:pecllist) { double('pecllist') }
+
+  before do
+    allow(Mixlib::ShellOut).to receive(:new).and_return(shellout)
+    allow(shellout).to receive(:run_command).and_return(pecllist)
+    allow(pecllist).to receive(:stdout).and_return('xdebug')
+    allow(File).to receive(:exist?).and_call_original
+    allow(File).to receive(:exist?).with('/usr/sbin/php5enmod').and_return(true)
+  end
+
+  context 'latest is required' do
+
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new do |node|
+        node.set['xdebug']['version'] = 'latest'
+        node.set['xdebug']['config_file'] = '/etc/php5/mods-available/xdebug.ini'
+        node.set['xdebug']['web_server']['service_name'] = ''
+        node.set['xdebug']['execute_php5enmod'] = true
+        node.set['xdebug']['stand_along'] = true
+      end.converge(described_recipe)
+    end
+
+    %w( apt build-essential php ).each do |recipe|
+      it "includes #{recipe}" do
+        expect(chef_run).to include_recipe(recipe)
+      end
+    end
+
+    it 'upgrade xdebug pear package to latest' do
+      expect(chef_run).to upgrade_php_pear('xdebug')
+    end
+
+    it 'install latest xdebug pear package' do
+      allow(pecllist).to receive(:stdout).and_return('')
+      expect(chef_run).to install_php_pear('xdebug')
+    end
+
+    it 'creates config file' do
+      expect(chef_run).to create_template('/etc/php5/mods-available/xdebug.ini').with(source: 'xdebug.ini.erb', owner: 'root', group: 'root', mode: 0644)
+    end
+
+    it 'execute php5enmod' do
+      expect(chef_run).to run_execute('/usr/sbin/php5enmod xdebug')
+    end
+  end
+
+  context 'not latest older version is required' do
+
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new do |node|
+        node.set['xdebug']['version'] = '2.3.3'
+        node.set['xdebug']['config_file'] = '/etc/php5/mods-available/xdebug.ini'
+        node.set['xdebug']['web_server']['service_name'] = ''
+      end.converge(described_recipe)
+    end
+
+    it 'install xdebug pear package 2.3.3 in case xdebug was installed' do
+      allow(pecllist).to receive(:stdout).and_return('xdebug')
+      expect(chef_run).to install_php_pear('xdebug').with(version: '2.3.3')
+    end
+
+    it 'install xdebug pear package 2.3.3 in case xdebug was not installed' do
+      allow(pecllist).to receive(:stdout).and_return('')
+      expect(chef_run).to install_php_pear('xdebug').with(version: '2.3.3')
+    end
+  end
 end

--- a/test/integration/default/serverspec/localhost/default_spec.rb
+++ b/test/integration/default/serverspec/localhost/default_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe 'xdebug::default' do
+
+  describe command('pecl list') do
+    its(:stdout) { should match /xdebug/ }
+  end
+
+  describe command('php -i') do
+    its(:stdout) { should match /xdebug support => enabled/ }
+    its(:stdout) { should match /xdebug.max_nesting_level => 256/ }
+    its(:stdout) { should match /xdebug.remote_cookie_expire_time => 3600/ }
+    its(:stdout) { should match /xdebug.remote_port => 9000/ }
+    its(:stdout) { should match /xdebug.var_display_max_children => 128/ }
+    its(:stdout) { should match /xdebug.var_display_max_data => 512/ }
+  end
+
+  describe file('/etc/php5/mods-available/xdebug.ini') do
+    it { should exist }
+    it { should be_file }
+  end
+end

--- a/test/integration/default/serverspec/spec_helper.rb
+++ b/test/integration/default/serverspec/spec_helper.rb
@@ -1,0 +1,3 @@
+require 'serverspec'
+
+set :backend, :exec


### PR DESCRIPTION
1. ```pear list``` command does not show xdebug in ubuntu 14, but pecl list shows it, and this PR switches them
2. When running chefspec in a system which does not have pear or pecl, following warning is shown: 
```'pear' is not recognized as an internal or external command, operable program or batch file.```
This PR switches direct execution of command to Mixlib::ShellOut and use rspec double for chefspec tests